### PR TITLE
Fix service deletion when using MongoDB

### DIFF
--- a/backend/routes/__tests__/services.delete.test.js
+++ b/backend/routes/__tests__/services.delete.test.js
@@ -1,0 +1,104 @@
+const express = require('express');
+const request = require('supertest');
+
+jest.mock('../../models/AIService', () => {
+  const services = [];
+  let nextId = 1;
+
+  const find = jest.fn(async () => services);
+  const findOne = jest.fn(async (cond) => services.find((s) => s.name === cond.name));
+  const findById = jest.fn(async (id) => services.find((s) => s._id === id || s.id === id));
+  const create = jest.fn(async (data) => {
+    const newId = String(nextId++);
+    const doc = {
+      _id: newId,
+      id: newId,
+      ...data,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
+    services.push(doc);
+    return doc;
+  });
+  const updateMany = jest.fn(async () => {});
+  const deleteOne = jest.fn(async (cond) => {
+    if (cond._id === undefined) {
+      throw new Error('Expected deleteOne to be called with _id when MongoDB is enabled');
+    }
+    const id = String(cond._id);
+    const index = services.findIndex((s) => s._id === id);
+    if (index !== -1) {
+      services.splice(index, 1);
+    }
+  });
+
+  return {
+    find,
+    findOne,
+    findById,
+    create,
+    updateMany,
+    deleteOne,
+    __reset: () => {
+      services.length = 0;
+      nextId = 1;
+      find.mockClear();
+      findOne.mockClear();
+      findById.mockClear();
+      create.mockClear();
+      updateMany.mockClear();
+      deleteOne.mockClear();
+    },
+  };
+});
+
+const servicesRouter = require('../services');
+const AIService = require('../../models/AIService');
+
+const buildApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/services', servicesRouter);
+  return app;
+};
+
+describe('Services API deletion with MongoDB backing store', () => {
+  const app = buildApp();
+
+  beforeEach(() => {
+    AIService.__reset();
+    delete global.AIService;
+  });
+
+  it('creates and deletes a service using _id when MongoDB is enabled', async () => {
+    const payload = {
+      name: 'Mongo Backed Service',
+      baseUrl: 'https://example.com',
+      tags: ['test'],
+      authMethod: 'none',
+      apiKey: '',
+      apiKeyHeader: 'Authorization',
+      apiKeyQuery: 'api_key',
+      isDefault: false,
+      enabled: true,
+      timeoutMs: 60000,
+      healthPath: '/prompt',
+      rps: 0,
+    };
+
+    const createRes = await request(app).post('/api/services').send(payload);
+    expect(createRes.status).toBe(200);
+    expect(createRes.body.success).toBe(true);
+
+    const serviceId = createRes.body.data.id;
+
+    const deleteRes = await request(app).delete(`/api/services/${serviceId}`);
+    expect(deleteRes.status).toBe(200);
+    expect(deleteRes.body.success).toBe(true);
+
+    expect(AIService.deleteOne).toHaveBeenCalledWith({ _id: serviceId });
+
+    const found = await AIService.findById(serviceId);
+    expect(found).toBeUndefined();
+  });
+});

--- a/backend/routes/services.js
+++ b/backend/routes/services.js
@@ -148,7 +148,9 @@ router.delete('/:id', async (req, res, next) => {
       return res.status(400).json({ success: false, message: '该服务已被任务或用户绑定，无法删除' });
     }
     
-    await AIService.deleteOne({ id: s.id });
+    const usingInMemoryStore = global.AIService && !Object.prototype.hasOwnProperty.call(s, '_id');
+    const deleteCondition = usingInMemoryStore ? { id: s.id } : { _id: s._id };
+    await AIService.deleteOne(deleteCondition);
     res.json({ success: true });
   } catch (err) { next(err); }
 });


### PR DESCRIPTION
## Summary
- ensure AI service deletions query by `_id` when running against MongoDB while preserving in-memory compatibility
- add a regression test that exercises create/delete flow with a MongoDB-like backing store stub

## Testing
- npm --prefix backend test

------
https://chatgpt.com/codex/tasks/task_e_68f894173fc0832797fab367ad3ed87e