### PR TITLE
Align app update flow with PATCH endpoint

### DIFF
--- a/frontend/src/components/AppConfigForm.jsx
+++ b/frontend/src/components/AppConfigForm.jsx
@@ -321,7 +321,7 @@ const AppConfigForm = ({ workflowData, initialData, onNext, onBack }) => {
       let response;
       if (initialData?.id) {
         // 更新应用
-        response = await axios.put(`/api/apps/${initialData.id}`, appConfig);
+        response = await axios.patch(`/api/apps/${initialData.id}`, appConfig);
       } else {
         // 创建应用
         response = await axios.post('/api/apps', appConfig);

--- a/tests/unit/apps.test.js
+++ b/tests/unit/apps.test.js
@@ -1,0 +1,139 @@
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import http from 'http';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const serverProxyPath = path.resolve(__dirname, '../server.cjs');
+const backendServerPath = path.resolve(__dirname, '../../backend/server.js');
+const appsRoutePath = path.resolve(__dirname, '../../backend/routes/apps.js');
+const appModelPath = path.resolve(__dirname, '../../backend/models/App.js');
+
+const createMockAppModel = () => {
+  const apps = new Map();
+
+  class MockApp {
+    constructor(data = {}) {
+      this._id = data._id || data.id || `app_${apps.size + 1}`;
+      Object.assign(this, data, { _id: this._id });
+    }
+
+    async save() {
+      apps.set(this._id, { ...this });
+      return this;
+    }
+
+    toJSON() {
+      return { ...this };
+    }
+  }
+
+  MockApp.__apps = apps;
+
+  MockApp.__seed = (data = {}) => {
+    const record = {
+      _id: data._id || data.id || `app_${apps.size + 1}`,
+      ...data
+    };
+    apps.set(record._id, record);
+    return record;
+  };
+
+  MockApp.findByIdAndUpdate = async (id, updates) => {
+    const existing = apps.get(id);
+    if (!existing) {
+      return null;
+    }
+
+    const updated = { ...existing, ...updates };
+    apps.set(id, updated);
+    return updated;
+  };
+
+  MockApp.findById = async (id) => apps.get(id) || null;
+
+  MockApp.findOne = async (query = {}) => {
+    for (const app of apps.values()) {
+      if (Object.entries(query).every(([key, value]) => app[key] === value)) {
+        return app;
+      }
+    }
+    return null;
+  };
+
+  MockApp.find = async () => Array.from(apps.values());
+
+  MockApp.countDocuments = async () => apps.size;
+
+  return MockApp;
+};
+
+let app;
+let testServer;
+let mockAppModel;
+
+beforeEach(async () => {
+  mockAppModel = createMockAppModel();
+  mockAppModel.__seed({
+    _id: 'app123',
+    name: 'Existing App',
+    workflowId: 'wf_1',
+    workflowVersion: 1,
+    timeoutSec: 60,
+    enableCache: false
+  });
+
+  require.cache[appModelPath] = { exports: mockAppModel };
+  delete require.cache[appsRoutePath];
+  delete require.cache[backendServerPath];
+  delete require.cache[serverProxyPath];
+
+  app = require('../server.cjs');
+  testServer = http.createServer(app);
+
+  await new Promise((resolve) => testServer.listen(0, resolve));
+});
+
+afterEach(async () => {
+  if (testServer) {
+    await new Promise((resolve) => testServer.close(resolve));
+    testServer = undefined;
+  }
+
+  delete require.cache[appModelPath];
+  delete require.cache[appsRoutePath];
+  delete require.cache[backendServerPath];
+  delete require.cache[serverProxyPath];
+});
+
+describe('Apps API', () => {
+  test('PATCH /api/apps/:id updates an existing app', async () => {
+    const { port } = testServer.address();
+    const response = await fetch(`http://127.0.0.1:${port}/api/apps/app123`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        timeoutSec: 120,
+        enableCache: true
+      })
+    });
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+
+    expect(body.timeoutSec).toBe(120);
+    expect(body.enableCache).toBe(true);
+
+    const storedApp = mockAppModel.__apps.get('app123');
+    expect(storedApp.timeoutSec).toBe(120);
+    expect(storedApp.enableCache).toBe(true);
+  });
+});
+


### PR DESCRIPTION
## Summary
- update the AppConfigForm submission logic to call the existing PATCH /api/apps/:id endpoint when editing
- add a Vitest suite that mocks the App model and verifies PATCH /api/apps/:id persists updates

## Testing
- npm test *(fails: backend/routes/__tests__/services.delete.test.js expects a Jest environment)*
- npx vitest tests/unit/apps.test.js


------
https://chatgpt.com/codex/tasks/task_e_68f898f72d6483278cfd3b25a4c163e4