### PR TITLE
Fix service persistence and secure management APIs

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -74,8 +74,7 @@ app.use('/api/users', authMiddleware, userRoutes);
 app.use('/api/projects', authMiddleware, projectRoutes);
 app.use('/api/files', authMiddleware, fileRoutes);
 app.use('/api/ai', authMiddleware, aiRoutes);
-// 阶段一：服务管理与代理接口先行，不强制鉴权
-app.use('/api/services', servicesRoutes);
+app.use('/api/services', authMiddleware, servicesRoutes);
 app.use('/api/comfy', comfyRoutes);
 app.use('/api/apps', authMiddleware, appsRoutes); // 应用相关路由，需要认证
 app.use('/api/uploads', uploadRoutes);


### PR DESCRIPTION
## Summary
- ensure service updates are persisted to the database while keeping in-memory fallback support
- require authentication for service management endpoints
- move the app name availability check ahead of dynamic routes and drop unused imports

## Testing
- npm test -- --run backend/routes/__tests__/services.delete.test.js

------
https://chatgpt.com/codex/tasks/task_e_68f9f5eb6fd48327a3c092479e4a198a