### PR TITLE
Ensure axios requests include auth token automatically

### DIFF
--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -1,0 +1,118 @@
+import axios from 'axios';
+
+const API_BASE_URL = import.meta.env?.VITE_API_BASE_URL || '/api';
+
+const TOKEN_STORAGE_KEYS = [
+  'token',
+  'authToken',
+  'auth_token',
+  'jwt',
+  'jwtToken',
+  'accessToken',
+  'canvas_token',
+  'canvasToken',
+];
+
+const WINDOW_TOKEN_KEYS = [
+  '__CANVAS_TOKEN__',
+  '__APP_TOKEN__',
+  '__JWT_TOKEN__',
+  '__AUTH_TOKEN__',
+  '__CANVAS_AUTH__',
+];
+
+const ensureBearerPrefix = (token) => {
+  if (!token) return token;
+  return token.startsWith('Bearer ') ? token : `Bearer ${token}`;
+};
+
+const readFromStorage = (storage) => {
+  if (!storage) return null;
+  for (const key of TOKEN_STORAGE_KEYS) {
+    try {
+      const value = storage.getItem(key);
+      if (value) {
+        return value;
+      }
+    } catch (_) {
+      // ignore storage access errors (e.g. security restrictions)
+    }
+  }
+  return null;
+};
+
+const readFromWindow = () => {
+  if (typeof window === 'undefined') return null;
+  for (const key of WINDOW_TOKEN_KEYS) {
+    const value = window[key];
+    if (typeof value === 'string' && value) {
+      return value;
+    }
+    if (value && typeof value === 'object' && typeof value.token === 'string') {
+      return value.token;
+    }
+  }
+  return null;
+};
+
+export const resolveAuthToken = () => {
+  const envToken = import.meta.env?.VITE_API_TOKEN || import.meta.env?.VITE_AUTH_TOKEN;
+  if (envToken) {
+    return envToken;
+  }
+
+  if (typeof window !== 'undefined') {
+    const localToken = readFromStorage(window.localStorage);
+    if (localToken) {
+      return localToken;
+    }
+
+    const sessionToken = readFromStorage(window.sessionStorage);
+    if (sessionToken) {
+      return sessionToken;
+    }
+  }
+
+  return readFromWindow();
+};
+
+const attachAuthHeader = (config) => {
+  const token = resolveAuthToken();
+  if (token) {
+    config.headers = config.headers || {};
+    if (!config.headers.Authorization) {
+      config.headers.Authorization = ensureBearerPrefix(token);
+    }
+  }
+  return config;
+};
+
+const configureClient = (client) => {
+  if (client.__canvasAuthConfigured) {
+    return client;
+  }
+
+  client.interceptors.request.use(attachAuthHeader, (error) => Promise.reject(error));
+
+  Object.defineProperty(client, '__canvasAuthConfigured', {
+    value: true,
+    enumerable: false,
+    configurable: false,
+    writable: false,
+  });
+
+  return client;
+};
+
+const apiClient = configureClient(
+  axios.create({
+    baseURL: API_BASE_URL,
+    withCredentials: true,
+  }),
+);
+
+axios.defaults.baseURL = API_BASE_URL;
+axios.defaults.withCredentials = true;
+configureClient(axios);
+
+export default apiClient;

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -1,9 +1,4 @@
-import axios from 'axios';
-
-const api = axios.create({
-  baseURL: '/api',
-  withCredentials: true,
-});
+import api from './httpClient.js';
 
 // Services
 export const listServices = async (params = {}) => {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.jsx'
 import './index.css'
+import './api/httpClient.js'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- add a shared axios client that injects authorization headers from env, storage, or window globals
- reuse the shared client across api helpers and initialize it during app bootstrap to cover direct axios usage

## Testing
- npm test -- --run *(fails: canvas native dependency missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa02e42cbc8327b92ce39fb006c0ac