### PR TITLE
Improve auth token detection for API client

### DIFF
--- a/src/api/httpClient.js
+++ b/src/api/httpClient.js
@@ -9,8 +9,23 @@ const TOKEN_STORAGE_KEYS = [
   'jwt',
   'jwtToken',
   'accessToken',
+  'access_token',
   'canvas_token',
   'canvasToken',
+  'canvasUser',
+  'user',
+  'userInfo',
+];
+
+const TOKEN_VALUE_KEYS = [
+  'token',
+  'accessToken',
+  'access_token',
+  'authToken',
+  'auth_token',
+  'jwt',
+  'jwtToken',
+  'value',
 ];
 
 const WINDOW_TOKEN_KEYS = [
@@ -21,6 +36,107 @@ const WINDOW_TOKEN_KEYS = [
   '__CANVAS_AUTH__',
 ];
 
+const COOKIE_TOKEN_KEYS = [
+  'token',
+  'authToken',
+  'auth_token',
+  'accessToken',
+  'access_token',
+  'jwt',
+  'jwtToken',
+  'canvas_token',
+  'canvasToken',
+];
+
+const isLikelyJwt = (value) => {
+  if (typeof value !== 'string') return false;
+  const token = value.trim().replace(/^Bearer\s+/i, '');
+  return token.split('.').length === 3;
+};
+
+const tryParseJson = (value) => {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed);
+  } catch (_) {
+    return null;
+  }
+};
+
+const findTokenInObject = (obj, depth = 0) => {
+  if (!obj || typeof obj !== 'object' || depth > 2) return null;
+
+  for (const key of TOKEN_VALUE_KEYS) {
+    const value = obj[key];
+    if (typeof value === 'string' && value) {
+      return value;
+    }
+  }
+
+  for (const value of Object.values(obj)) {
+    if (typeof value === 'string' && isLikelyJwt(value)) {
+      return value;
+    }
+    if (typeof value === 'object') {
+      const nested = findTokenInObject(value, depth + 1);
+      if (nested) {
+        return nested;
+      }
+    }
+  }
+
+  return null;
+};
+
+const extractToken = (raw) => {
+  if (!raw) return null;
+
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+
+    if (trimmed.startsWith('{') || trimmed.startsWith('[') || trimmed.startsWith('"')) {
+      const parsed = tryParseJson(trimmed);
+      if (parsed) {
+        return extractToken(parsed);
+      }
+    }
+
+    if (trimmed.startsWith('Bearer ')) {
+      return trimmed;
+    }
+
+    if (isLikelyJwt(trimmed)) {
+      return trimmed;
+    }
+
+    if (/token=/i.test(trimmed)) {
+      const match = trimmed.match(/token=([^&;]+)/i);
+      if (match?.[1]) {
+        return match[1];
+      }
+    }
+
+    return null;
+  }
+
+  if (typeof raw === 'object') {
+    return findTokenInObject(raw);
+  }
+
+  return null;
+};
+
+const safeGetStorageItem = (storage, key) => {
+  try {
+    return storage.getItem(key);
+  } catch (_) {
+    return null;
+  }
+};
+
 const ensureBearerPrefix = (token) => {
   if (!token) return token;
   return token.startsWith('Bearer ') ? token : `Bearer ${token}`;
@@ -29,13 +145,21 @@ const ensureBearerPrefix = (token) => {
 const readFromStorage = (storage) => {
   if (!storage) return null;
   for (const key of TOKEN_STORAGE_KEYS) {
-    try {
-      const value = storage.getItem(key);
-      if (value) {
-        return value;
+    const candidate = extractToken(safeGetStorageItem(storage, key));
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  // Fallback: inspect all keys to support unknown storage names
+  if (typeof storage.length === 'number' && storage.length > 0) {
+    for (let index = 0; index < storage.length; index += 1) {
+      const key = storage.key(index);
+      if (!key) continue;
+      const candidate = extractToken(safeGetStorageItem(storage, key));
+      if (candidate) {
+        return candidate;
       }
-    } catch (_) {
-      // ignore storage access errors (e.g. security restrictions)
     }
   }
   return null;
@@ -45,13 +169,39 @@ const readFromWindow = () => {
   if (typeof window === 'undefined') return null;
   for (const key of WINDOW_TOKEN_KEYS) {
     const value = window[key];
-    if (typeof value === 'string' && value) {
-      return value;
-    }
-    if (value && typeof value === 'object' && typeof value.token === 'string') {
-      return value.token;
+    const candidate = extractToken(value);
+    if (candidate) {
+      return candidate;
     }
   }
+  return null;
+};
+
+const readFromCookies = () => {
+  if (typeof document === 'undefined' || typeof document.cookie !== 'string') {
+    return null;
+  }
+
+  const cookies = document.cookie.split(';');
+  for (const rawCookie of cookies) {
+    const [name, ...rest] = rawCookie.split('=');
+    if (!name) continue;
+    const trimmedName = name.trim();
+    const value = rest.join('=').trim();
+    if (!value) continue;
+
+    if (COOKIE_TOKEN_KEYS.includes(trimmedName)) {
+      const candidate = extractToken(value);
+      if (candidate) {
+        return candidate;
+      }
+    }
+
+    if (isLikelyJwt(value)) {
+      return value;
+    }
+  }
+
   return null;
 };
 
@@ -73,7 +223,12 @@ export const resolveAuthToken = () => {
     }
   }
 
-  return readFromWindow();
+  const windowToken = readFromWindow();
+  if (windowToken) {
+    return windowToken;
+  }
+
+  return readFromCookies();
 };
 
 const attachAuthHeader = (config) => {

--- a/src/components/AppBuilder.jsx
+++ b/src/components/AppBuilder.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '@/api/index.js';
 import WorkflowUploader from './WorkflowUploader';
 import AppConfigForm from './AppConfigForm';
 import PageBuilder from './PageBuilder';
@@ -46,7 +46,7 @@ const AppBuilder = () => {
       // 假设有一个 API 来获取应用详情
       const fetchAppDetails = async () => {
         try {
-          const response = await axios.get(`/api/apps/${currentAppId}`);
+          const response = await api.get(`/apps/${currentAppId}`);
           initApp(response.data.data); // 初始化 AppBuilderStore
           fetchWorkflow(response.data.data.workflowId); // 加载关联的工作流
         } catch (error) {

--- a/src/components/AppConfigForm.jsx
+++ b/src/components/AppConfigForm.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import axios from 'axios';
+import api from '@/api/index.js';
 import useWorkflowStore from '@/store/useWorkflowStore';
 import useAppBuilderStore from '@/store/useAppBuilderStore';
 import ParameterCascader from '@/components/ParameterCascader';
@@ -187,10 +187,10 @@ const AppConfigForm = ({ onNext, onBack }) => {
       let response;
       if (appId) {
         // Update existing app
-        response = await axios.patch(`/api/apps/${appId}`, appConfig);
+        response = await api.patch(`/apps/${appId}`, appConfig);
       } else {
         // Create new app
-        response = await axios.post('/api/apps', appConfig);
+        response = await api.post('/apps', appConfig);
       }
       const savedApp = response.data.data;
       initApp(savedApp); // Update the store with the saved app data

--- a/src/components/AppRunner.jsx
+++ b/src/components/AppRunner.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useMemo } from 'react';
-import axios from 'axios';
+import api from '@/api/index.js';
 import { useParams } from 'react-router-dom';
 import useAppBuilderStore from '../store/useAppBuilderStore';
 import useWorkflowStore from '../store/useWorkflowStore';
@@ -38,7 +38,7 @@ const AppRunner = () => {
       setLoading(true);
       setError(null);
       try {
-        const response = await axios.get(`/api/apps/${resolvedAppId}`);
+        const response = await api.get(`/apps/${resolvedAppId}`);
         const appData = response.data?.data;
         if (appData) {
           initApp(appData);
@@ -108,7 +108,7 @@ const AppRunner = () => {
           }
         });
 
-      const response = await axios.post(`/api/comfy/apps/${resolvedAppId}/run`, {
+      const response = await api.post(`/comfy/apps/${resolvedAppId}/run`, {
         uiInputs: payloadInputs,
       });
 

--- a/src/components/ExecutionHistory.jsx
+++ b/src/components/ExecutionHistory.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '@/api/index.js';
 
 const ExecutionHistory = ({ appId }) => {
   const [history, setHistory] = useState([]);
@@ -15,7 +15,7 @@ const ExecutionHistory = ({ appId }) => {
   const loadHistory = async () => {
     setLoading(true);
     try {
-      const response = await axios.get(`/api/apps/${appId}/history`);
+      const response = await api.get(`/apps/${appId}/history`);
       setHistory(response.data);
     } catch (error) {
       console.error('加载执行历史失败', error);

--- a/src/components/PageBuilder.jsx
+++ b/src/components/PageBuilder.jsx
@@ -6,7 +6,7 @@ import useTranslation from "@/hooks/useTranslation";
 import useAppBuilderStore from "@/store/useAppBuilderStore";
 import useWorkflowStore from "@/store/useWorkflowStore";
 import ParameterCascader from '@/components/ParameterCascader';
-import axios from 'axios';
+import api from '@/api/index.js';
 
 // 可视化组件渲染器
 const ComponentRenderer = ({
@@ -634,7 +634,7 @@ const PageBuilder = ({ onNext, onBack }) => {
       return;
     }
     try {
-      const response = await axios.patch(`/api/apps/${appId}`, {
+      const response = await api.patch(`/apps/${appId}`, {
         components: components,
         uiBindings: uiBindings,
       });

--- a/src/components/ServiceManager.jsx
+++ b/src/components/ServiceManager.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
+import api from '@/api/index.js';
 import { useNavigate } from 'react-router-dom'; // 添加useNavigate导入
 
 const ServiceManager = () => {
@@ -26,7 +26,7 @@ const ServiceManager = () => {
   const fetchServices = async () => {
     try {
       setLoading(true);
-      const response = await axios.get('/api/services');
+      const response = await api.get('/services');
       setServices(response.data.data || []);
     } catch (error) {
       console.error('获取服务列表失败:', error);
@@ -71,10 +71,10 @@ const ServiceManager = () => {
       setLoading(true);
       if (editingService) {
         // 更新服务
-        await axios.put(`/api/services/${editingService.id}`, formData);
+        await api.put(`/services/${editingService.id}`, formData);
       } else {
         // 创建服务
-        await axios.post('/api/services', formData);
+        await api.post('/services', formData);
       }
       setShowForm(false);
       setEditingService(null);
@@ -131,7 +131,7 @@ const ServiceManager = () => {
       
       if (window.confirm('确定要删除这个服务吗？')) {
         try {
-          await axios.delete(`/api/services/${serviceId}`);
+          await api.delete(`/services/${serviceId}`);
           fetchServices();
         } catch (error) {
           console.error('删除服务失败:', error);
@@ -142,7 +142,7 @@ const ServiceManager = () => {
       // 即使检测失败，也允许用户确认是否删除
       if (window.confirm('确定要删除这个服务吗？')) {
         try {
-          await axios.delete(`/api/services/${serviceId}`);
+          await api.delete(`/services/${serviceId}`);
           fetchServices();
         } catch (error) {
           console.error('删除服务失败:', error);
@@ -154,7 +154,7 @@ const ServiceManager = () => {
   // 设置默认服务
   const handleSetDefault = async (serviceId) => {
     try {
-      await axios.post(`/api/services/${serviceId}/set-default`);
+      await api.post(`/services/${serviceId}/set-default`);
       fetchServices();
     } catch (error) {
       console.error('设置默认服务失败:', error);
@@ -165,7 +165,7 @@ const ServiceManager = () => {
   // 健康检查
   const handleHealthCheck = async (serviceId) => {
     try {
-      await axios.post(`/api/services/${serviceId}/health-check`);
+      await api.post(`/services/${serviceId}/health-check`);
       fetchServices();
     } catch (error) {
       console.error('健康检查失败:', error);

--- a/src/components/WorkflowParameterManager.jsx
+++ b/src/components/WorkflowParameterManager.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
 
 const WorkflowParameterManager = ({ workflowData, onParametersChange }) => {
   const [parameters, setParameters] = useState({});


### PR DESCRIPTION
## Summary
- expand the shared API client's token resolution to cover additional storage and cookie locations used for auth tokens
- parse JSON-encoded token payloads and reuse discovered tokens when attaching the Authorization header

## Testing
- npm run lint *(fails: existing lint errors across backend configuration, middleware, tests, and assorted frontend utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68feda9682008327b90d6cdae8634f27